### PR TITLE
nohide flag in screenkey to allow the option of keeping the key screen persistant after timeout.

### DIFF
--- a/screenkey/Screenkey/screenkey.py
+++ b/screenkey/Screenkey/screenkey.py
@@ -3,12 +3,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -53,11 +53,13 @@ class Screenkey(gtk.Window):
         MODE_NORMAL:_('Normal'),
     }
 
-    STATE_FILE = os.path.join(glib.get_user_cache_dir(), 
+    STATE_FILE = os.path.join(glib.get_user_cache_dir(),
                               'screenkey.dat')
 
-    def __init__(self, logger, nodetach, timeout, size, mode, position, opacity, bgcolor, font#, color):
-            ):
+    def __init__(self, logger, nodetach, timeout, size, mode, position,
+                 opacity, bgcolor, font, nohide#, color):
+                ):
+
         gtk.Window.__init__(self)
 
         self.timer = None
@@ -79,6 +81,10 @@ class Screenkey(gtk.Window):
             self.logger.debug("Detach from the parent.")
             self.drop_tty()
 
+        self.no_hide = nohide
+        if nohide:
+            self.show()
+
         self.set_skip_taskbar_hint(True)
         self.set_skip_pager_hint(True)
         self.set_keep_above(True)
@@ -91,7 +97,7 @@ class Screenkey(gtk.Window):
         self.modify_bg(gtk.STATE_NORMAL, bgcolor)
         self.set_opacity(self.options['opacity'])
 
-        gobject.signal_new("text-changed", gtk.Label, 
+        gobject.signal_new("text-changed", gtk.Label,
                         gobject.SIGNAL_RUN_FIRST, gobject.TYPE_NONE, ())
         self.label = gtk.Label()
         self.label.set_justify(gtk.JUSTIFY_RIGHT)
@@ -107,7 +113,7 @@ class Screenkey(gtk.Window):
         self.set_gravity(gtk.gdk.GRAVITY_CENTER)
         self.set_xy_position(self.options['position'])
 
-        self.listenkbd = ListenKbd(self.label, logger=self.logger, 
+        self.listenkbd = ListenKbd(self.label, logger=self.logger,
                                    mode=self.options['mode'])
         self.listenkbd.start()
 
@@ -143,8 +149,8 @@ class Screenkey(gtk.Window):
 
         try:
             import appindicator
-            self.systray = appindicator.Indicator(APP_NAME, 
-                           'indicator-messages', 
+            self.systray = appindicator.Indicator(APP_NAME,
+                           'indicator-messages',
                             appindicator.CATEGORY_APPLICATION_STATUS)
             self.systray.set_status(appindicator.STATUS_ACTIVE)
             self.systray.set_attention_icon("indicator-messages-new")
@@ -156,7 +162,7 @@ class Screenkey(gtk.Window):
             self.systray = gtk.StatusIcon()
             self.systray.set_from_icon_name(
                     "preferences-desktop-keyboard-shortcuts")
-            self.systray.connect("popup-menu", 
+            self.systray.connect("popup-menu",
                     self.on_statusicon_popup, menu)
             self.logger.debug("Using StatusIcon.")
 
@@ -178,7 +184,7 @@ class Screenkey(gtk.Window):
             except:
                 f.close()
         except IOError:
-            self.logger.debug("file %s does not exists." % 
+            self.logger.debug("file %s does not exists." %
                               self.STATE_FILE)
         return options
 
@@ -226,7 +232,7 @@ class Screenkey(gtk.Window):
         if button == 3:
             if data:
                 data.show()
-                data.popup(None, None, gtk.status_icon_position_menu, 
+                data.popup(None, None, gtk.status_icon_position_menu,
                            3, timestamp, widget)
 
     def on_label_change(self, widget, data=None):
@@ -244,20 +250,21 @@ class Screenkey(gtk.Window):
 
     def on_timeout(self):
         gtk.gdk.threads_enter()
-        self.hide()
+        if not self.no_hide:
+            self.hide()
         self.label.set_text("")
         gtk.gdk.threads_leave()
 
     def on_change_mode(self, mode):
         self.listenkbd.stop()
-        self.listenkbd = ListenKbd(self.label, logger=self.logger, 
+        self.listenkbd = ListenKbd(self.label, logger=self.logger,
                                    mode=mode)
         self.listenkbd.start()
 
     def on_show_keys(self, widget, data=None):
         if widget.get_active():
             self.logger.debug("Screenkey enabled.")
-            self.listenkbd = ListenKbd(self.label, logger=self.logger, 
+            self.listenkbd = ListenKbd(self.label, logger=self.logger,
                                        mode=self.options['mode'])
             self.listenkbd.start()
         else:
@@ -265,8 +272,8 @@ class Screenkey(gtk.Window):
             self.listenkbd.stop()
 
     def on_preferences_dialog(self, widget, data=None):
-        prefs = gtk.Dialog(APP_NAME, None, 
-                    gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT, 
+        prefs = gtk.Dialog(APP_NAME, None,
+                    gtk.DIALOG_MODAL | gtk.DIALOG_DESTROY_WITH_PARENT,
                     (gtk.STOCK_CLOSE, gtk.RESPONSE_CLOSE))
 
         def on_sb_time_changed(widget, data=None):
@@ -312,11 +319,11 @@ class Screenkey(gtk.Window):
         sb_time.set_update_policy(gtk.UPDATE_IF_VALID)
         sb_time.set_value(self.options['timeout'])
         sb_time.connect("value-changed", on_sb_time_changed)
-        hbox_time.pack_start(lbl_time1, expand=False, 
+        hbox_time.pack_start(lbl_time1, expand=False,
                              fill=False, padding=6)
-        hbox_time.pack_start(sb_time, expand=False, 
+        hbox_time.pack_start(sb_time, expand=False,
                              fill=False, padding=4)
-        hbox_time.pack_start(lbl_time2, expand=False, 
+        hbox_time.pack_start(lbl_time2, expand=False,
                              fill=False, padding=4)
         frm_time.add(hbox_time)
         frm_time.show_all()
@@ -337,9 +344,9 @@ class Screenkey(gtk.Window):
         cbox_positions.set_active(self.options['position'])
         cbox_positions.connect("changed", on_cbox_changed)
 
-        hbox1_aspect.pack_start(lbl_positions, expand=False, 
+        hbox1_aspect.pack_start(lbl_positions, expand=False,
                                 fill=False, padding=6)
-        hbox1_aspect.pack_start(cbox_positions, expand=False, 
+        hbox1_aspect.pack_start(cbox_positions, expand=False,
                                 fill=False, padding=4)
 
         hbox2_aspect = gtk.HBox()
@@ -352,9 +359,9 @@ class Screenkey(gtk.Window):
         cbox_sizes.set_active(self.options['size'])
         cbox_sizes.connect("changed", on_cbox_sizes_changed)
 
-        hbox2_aspect.pack_start(lbl_sizes, expand=False, 
+        hbox2_aspect.pack_start(lbl_sizes, expand=False,
                                 fill=False, padding=6)
-        hbox2_aspect.pack_start(cbox_sizes, expand=False, 
+        hbox2_aspect.pack_start(cbox_sizes, expand=False,
                                 fill=False, padding=4)
 
         vbox_aspect.pack_start(hbox1_aspect)
@@ -373,9 +380,9 @@ class Screenkey(gtk.Window):
             cbox_modes.insert_text(key, value)
         cbox_modes.set_active(self.options['mode'])
         cbox_modes.connect("changed", on_cbox_modes_changed)
-        hbox_kbd.pack_start(lbl_kbd, expand=False, 
+        hbox_kbd.pack_start(lbl_kbd, expand=False,
                             fill=False, padding=6)
-        hbox_kbd.pack_start(cbox_modes, expand=False, 
+        hbox_kbd.pack_start(cbox_modes, expand=False,
                             fill=False, padding=4)
         frm_kbd.add(hbox_kbd)
 

--- a/screenkey/screenkey
+++ b/screenkey/screenkey
@@ -53,8 +53,6 @@ def Main():
         help=_("font"), default='Sans')
     parser.add_option("-n", "--no-hide", action="store_true",
         dest="nohide", default=False, help=_("do not hide"))
-#    parser.add_option("-n", "--no-hide", action="store_true", dest="nohide",
-#        help=_("do not hide"), default=False)
     #parser.add_option("-c", "--color", type="string",
         #dest="color", help=_("color"), default='TODO')
     (options, args) = parser.parse_args()

--- a/screenkey/screenkey
+++ b/screenkey/screenkey
@@ -4,12 +4,12 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -32,8 +32,8 @@ gtk.gdk.threads_init()
 
 def Main():
     parser = OptionParser(description=APP_DESC, version=VERSION)
-    parser.add_option("--no-detach", action="store_true", 
-        dest="nodetach", default=False, 
+    parser.add_option("--no-detach", action="store_true",
+        dest="nodetach", default=False,
         help=_("do not detach from the parent"))
     parser.add_option("-d", "--debug", action="store_true",
         dest="debug", default=False, help=_("show debug information"))
@@ -51,6 +51,10 @@ def Main():
         help=_("bgcolor"), default='black')
     parser.add_option("-f", "--font", type="string", dest="font",
         help=_("font"), default='Sans')
+    parser.add_option("-n", "--no-hide", action="store_true",
+        dest="nohide", default=False, help=_("do not hide"))
+#    parser.add_option("-n", "--no-hide", action="store_true", dest="nohide",
+#        help=_("do not hide"), default=False)
     #parser.add_option("-c", "--color", type="string",
         #dest="color", help=_("color"), default='TODO')
     (options, args) = parser.parse_args()
@@ -60,7 +64,7 @@ def Main():
             # Send debug messages to standard output
             logfile = None
         else:
-            logfile = os.path.join(os.path.expanduser('~'), 
+            logfile = os.path.join(os.path.expanduser('~'),
                                    '.screenkey.log')
             username = os.environ.get('SUDO_USER')
             if username:
@@ -79,6 +83,7 @@ def Main():
             position=options.position,
             opacity=options.opacity,
             bgcolor=options.bgcolor,
+            nohide=options.nohide,
             font=options.font#,
             #color=options.color)
             )


### PR DESCRIPTION
First, I read https://github.com/KeyboardFire/mkcast/issues/5 and I liked the idea of having the option to make the screenkey screen not automatically hide. I use a tiling window manager (Xmonad) by default, and this enables me to use (a small variant of) mkcast there instead of flipping to GNOME.

This causes no changes on behalf of the user at the moment. On the other hand, the functionality is not viewable at the moment either. I'm only partially proficient at bash scripting (embarrasing to say), and I'm not sure of the best way to take a flag given to mkcast or newcast and to pass it to screenkey. But this should be easy. I foresee the ability to type `newcast -n` and have the `-n` flag ultimately passed to screenkey "nohide".
