### PR TITLE
Fixed mkcast duration param

### DIFF
--- a/mkcast
+++ b/mkcast
@@ -65,7 +65,7 @@ then
     ENDSTR="bash -c 'while kill -0 ${duration:1}; do :; done'"
 else
     ENDCMD="-d"
-    ENDSTR="duration"
+    ENDSTR="${duration}"
 fi
 
 # start recording the window


### PR DESCRIPTION
Duration was previously set to the string
"duration" and not the actual duration time
that was entered in by the user.
