### PR TITLE
Fix typo in makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ PREFIX = /usr/local
 
 install:
 	install -Dm 755 mkcast $(DESTDIR)$(PREFIX)/bin/mkcast
-	install -Dm 755 newcast $(DESTDIR)$(PREFIX)/bin/mkcast
+	install -Dm 755 newcast $(DESTDIR)$(PREFIX)/bin/newcast


### PR DESCRIPTION
There was a typo on #24 that overwrote `mkcast` with `newcast`.

Sorry about that. ☺
